### PR TITLE
change the repository link

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
         <p>Angela G.</p>
         <a href="mailto:angelakgo20@gmail.com" target="_blank" rel="noopener"><img class="icono" src="/svg/envelope.svg"
                 alt="e-mail icon" /></a>
-        <a href="https://github.com/angela-goncalves/fcc-tribute-page" target="_blank" rel="noopener"><img class="icono"
+        <a href="https://github.com/angela-goncalves/fcc-Landing-page" target="_blank" rel="noopener"><img class="icono"
                 src="/svg/github.svg" alt="github icon" /></a>
         <a href="https://codepen.io/angela-goncalves" target="_blank" rel="noopener"><img class="icono"
                 src="/svg/codepenicon.svg" alt="codepen icon" /></a>


### PR DESCRIPTION
Was changed the github icon's link, in the footer,  because had the link to a wrong repository. 